### PR TITLE
Changed the dateFormat string because before dateFormatter.dateFormat…

### DIFF
--- a/AAPickerView/Classes/AAPickerView.swift
+++ b/AAPickerView/Classes/AAPickerView.swift
@@ -39,7 +39,7 @@ open class AAPickerView: UITextField {
         }
         set {
             inputView = newValue
-            dateFormatter.dateFormat = "MM/dd/YYYY"
+            dateFormatter.dateFormat = "MM/dd/yyyy"
             
         }
     }


### PR DESCRIPTION
… was incorrect which results in Date->String conversion inaccuracy

The "YYYY" just needed to be "yyyy" on the dateFormatter.dateFormat string.  Otherwise, dates were converted to strings incorrectly.  (Eg: try "December 12, 1964" as a Date - It will convert to "December 12, 1965" as a String with the dateFormat as "MM/dd/YYYY"